### PR TITLE
Fix linguist language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,11 @@
 * text=auto
-*.css linguist-vendored
-*.scss linguist-vendored
-*.js linguist-vendored
 CHANGELOG.md export-ignore
+
+public/index.php            linguist-generated
+resources/js/app.js         linguist-generated
+resources/js/bootstrap.js   linguist-generated
+resources/sass              linguist-generated
+
+public/assets/vendor                        linguist-vendored
+public/assets/admin/css/sb-admin-2.css      linguist-vendored
+public/assets/admin/css/sb-admin-2.min.css  linguist-vendored


### PR DESCRIPTION
Fix linguist language detection by modifying laravel default .gitattributes

Laravel default .gitattributes ignores : 
- Javascript
- CSS
- SCSS