### PR TITLE
Prevent double "/" when creating assets links

### DIFF
--- a/app/Extensions/Theme/ThemeManager.php
+++ b/app/Extensions/Theme/ThemeManager.php
@@ -111,7 +111,7 @@ class ThemeManager extends ExtensionManager
             $theme = $this->currentTheme;
         }
 
-        return $this->themesPath("/{$theme}/{$path}");
+        return $this->themesPath("{$theme}/{$path}");
     }
 
     /**


### PR DESCRIPTION
You can refer to this screenshot
![link with double /](https://i.imgur.com/wPrTjvB.png)

Maybe can we do the same for the `publicPath` function? (I don't looked at it)