### PR TITLE
Group routes with the same uri

### DIFF
--- a/routes/admin.php
+++ b/routes/admin.php
@@ -47,8 +47,10 @@ Route::prefix('users')->name('users.')->middleware('can:admin.users')->group(fun
 Route::prefix('themes')->name('themes.')->middleware('can:admin.themes')->group(function () {
     Route::get('/', 'ThemeController@index')->name('index');
     Route::post('/change/{theme?}', 'ThemeController@changeTheme')->name('change');
-    Route::get('/{theme}/config', 'ThemeController@edit')->name('edit');
-    Route::post('/{theme}/config', 'ThemeController@config')->name('config');
+    Route::prefix('/{theme}/config')->group(function () {
+        Route::get('/', 'ThemeController@edit')->name('edit');
+        Route::post('/', 'ThemeController@config')->name('config');
+    });
     Route::post('/{theme}/update', 'ThemeController@update')->name('update');
     Route::post('/{themeId}/download', 'ThemeController@download')->name('download');
     Route::delete('/{theme}', 'ThemeController@delete')->name('delete');

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,7 +21,7 @@ Route::prefix('/auth')->name('auth.')->group(function () {
     Route::post('/logout', 'AuthController@logout')->name('logout');
 });
 
-Route::prefix('/azlink')->middleware('server.token')->group(function () {
-    Route::get('/', 'ServerController@status')->name('azlink');
+Route::prefix('/azlink')->name('azlink')->middleware('server.token')->group(function () {
+    Route::get('/', 'ServerController@status');
     Route::post('/', 'ServerController@fetch');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,9 +21,7 @@ Route::prefix('/auth')->name('auth.')->group(function () {
     Route::post('/logout', 'AuthController@logout')->name('logout');
 });
 
-Route::middleware('server.token')->group(function () {
-    Route::prefix('/azlink')->group(function () {
-        Route::get('/', 'ServerController@status')->name('azlink');
-        Route::post('/', 'ServerController@fetch');
-    });
+Route::prefix('/azlink')->middleware('server.token')->group(function () {
+    Route::get('/', 'ServerController@status')->name('azlink');
+    Route::post('/', 'ServerController@fetch');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,7 +21,7 @@ Route::prefix('/auth')->name('auth.')->group(function () {
     Route::post('/logout', 'AuthController@logout')->name('logout');
 });
 
-Route::prefix('/azlink')->name('azlink')->middleware('server.token')->group(function () {
-    Route::get('/', 'ServerController@status');
+Route::prefix('/azlink')->middleware('server.token')->group(function () {
+    Route::get('/', 'ServerController@status')->name('azlink');
     Route::post('/', 'ServerController@fetch');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,6 +22,8 @@ Route::prefix('/auth')->name('auth.')->group(function () {
 });
 
 Route::middleware('server.token')->group(function () {
-    Route::get('/azlink', 'ServerController@status')->name('azlink');
-    Route::post('/azlink', 'ServerController@fetch');
+    Route::prefix('/azlink')->group(function () {
+        Route::get('/', 'ServerController@status')->name('azlink');
+        Route::post('/', 'ServerController@fetch');
+    });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,8 +23,10 @@ Route::prefix('user')->group(function () {
         'register' => setting('register', true),
     ]);
 
-    Route::get('/2fa', 'Auth\LoginController@show2fa')->name('login.2fa');
-    Route::post('/2fa', 'Auth\LoginController@login2fa');
+    Route::prefix('/2fa')->group(function () {
+        Route::get('/', 'Auth\LoginController@show2fa')->name('login.2fa');
+        Route::post('/', 'Auth\LoginController@login2fa');
+    });
 });
 
 Route::prefix('profile')->name('profile.')->middleware('auth')->group(function () {
@@ -46,8 +48,10 @@ Route::prefix('news')->name('posts.')->group(function () {
     Route::get('/{post:slug}', 'PostController@show')->name('show');
 
     Route::middleware('auth')->group(function () {
-        Route::post('/{post}/like', 'PostLikeController@addLike')->name('like');
-        Route::delete('/{post}/like', 'PostLikeController@removeLike')->name('dislike');
+        Route::prefix('/{post}/like')->group(function () {
+            Route::post('/', 'PostLikeController@addLike')->name('like');
+            Route::delete('/', 'PostLikeController@removeLike')->name('dislike');
+        });
     });
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,8 +23,8 @@ Route::prefix('user')->group(function () {
         'register' => setting('register', true),
     ]);
 
-    Route::prefix('/2fa')->group(function () {
-        Route::get('/', 'Auth\LoginController@show2fa')->name('login.2fa');
+    Route::prefix('/2fa')->name('login.2fa')->group(function () {
+        Route::get('/', 'Auth\LoginController@show2fa');
         Route::post('/', 'Auth\LoginController@login2fa');
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,9 +23,9 @@ Route::prefix('user')->group(function () {
         'register' => setting('register', true),
     ]);
 
-    Route::prefix('/2fa')->name('login.2fa')->group(function () {
-        Route::get('/', 'Auth\LoginController@show2fa');
-        Route::post('/', 'Auth\LoginController@login2fa');
+    Route::prefix('/2fa')->name('login.')->group(function () {
+        Route::get('/', 'Auth\LoginController@show2fa')->name('2fa');
+        Route::post('/', 'Auth\LoginController@login2fa')->name('2fa-verify');
     });
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,11 +47,9 @@ Route::prefix('news')->name('posts.')->group(function () {
     Route::get('/', 'PostController@index')->name('index');
     Route::get('/{post:slug}', 'PostController@show')->name('show');
 
-    Route::middleware('auth')->group(function () {
-        Route::prefix('/{post}/like')->group(function () {
-            Route::post('/', 'PostLikeController@addLike')->name('like');
-            Route::delete('/', 'PostLikeController@removeLike')->name('dislike');
-        });
+    Route::prefix('/{post}/like')->middleware('auth')->group(function () {
+        Route::post('/', 'PostLikeController@addLike')->name('like');
+        Route::delete('/', 'PostLikeController@removeLike')->name('dislike');
     });
 });
 


### PR DESCRIPTION
Goal : Make uri changes easier

To check if I break things or not, I was running the following command : `php artisan route:list > routes.txt && diff routes_orig.txt routes.txt`

This is the original route:list output before changes : [routes_orig.txt](https://github.com/Azuriom/Azuriom/files/4335399/routes_orig.txt)
This is the route:list output after changes : [routes.txt](https://github.com/Azuriom/Azuriom/files/4335506/routes.txt)


Diff is not empty anymore, because of the last commit, but it should not break anything.

Don't hesitate to regenerate routes.txt if you want.
I hope I didn't break anything
