### PR TITLE
Add a Language middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -39,6 +39,7 @@ class Kernel extends HttpKernel
             \Azuriom\Http\Middleware\VerifyCsrfToken::class,
             \Azuriom\Http\Middleware\CheckForMaintenanceSettings::class,
             \Azuriom\Http\Middleware\LogoutIfSuspended::class,
+            \Azuriom\Http\Middleware\Language::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
 

--- a/app/Http/Middleware/Language.php
+++ b/app/Http/Middleware/Language.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Azuriom\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Filesystem\Filesystem;
+
+class Language
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+    	$locales = array_map('basename', app()->make(Filesystem::class)->directories(resource_path('lang')));
+    	$locale = $request->session()->get('locale', $request->getPreferredLanguage($locales));
+
+        app()->setLocale($locale);
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/Language.php
+++ b/app/Http/Middleware/Language.php
@@ -3,8 +3,8 @@
 namespace Azuriom\Http\Middleware;
 
 use Closure;
-use Illuminate\Http\Request;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Http\Request;
 
 class Language
 {
@@ -17,8 +17,8 @@ class Language
      */
     public function handle(Request $request, Closure $next)
     {
-    	$locales = array_map('basename', app()->make(Filesystem::class)->directories(resource_path('lang')));
-    	$locale = $request->session()->get('locale', $request->getPreferredLanguage($locales));
+        $locales = array_map('basename', app()->make(Filesystem::class)->directories(resource_path('lang')));
+        $locale = $request->session()->get('locale', $request->getPreferredLanguage($locales));
 
         app()->setLocale($locale);
 


### PR DESCRIPTION
This middleware allows first, to get the language from the session, if it is absent, it will be the language of the browser that will be taken into account. Otherwise, it will choose the default language of the website.

Should I cache $locales / make it a helper?