### PR TITLE
make navbar name longer

### DIFF
--- a/app/Http/Requests/NavbarElementRequest.php
+++ b/app/Http/Requests/NavbarElementRequest.php
@@ -46,7 +46,7 @@ class NavbarElementRequest extends FormRequest
     public function rules()
     {
         return [
-            'name' => ['required', 'string', 'max:50'],
+            'name' => ['required', 'string', 'max:150'],
             'type' => ['string', Rule::in(NavbarElement::types())],
             'link' => ['required_if:type,link', 'nullable', 'string', 'max:150'],
             'plugin' => ['required_if:type,plugin', 'nullable', Rule::in(plugins()->getRouteDescriptions()->keys())],

--- a/app/Http/Requests/NavbarElementRequest.php
+++ b/app/Http/Requests/NavbarElementRequest.php
@@ -46,7 +46,7 @@ class NavbarElementRequest extends FormRequest
     public function rules()
     {
         return [
-            'name' => ['required', 'string', 'max:150'],
+            'name' => ['required', 'string', 'max:100'],
             'type' => ['string', Rule::in(NavbarElement::types())],
             'link' => ['required_if:type,link', 'nullable', 'string', 'max:150'],
             'plugin' => ['required_if:type,plugin', 'nullable', Rule::in(plugins()->getRouteDescriptions()->keys())],


### PR DESCRIPTION
[78ffe87](https://github.com/Azuriom/Azuriom/commit/78ffe87886cea8a6372b459b8ba3e95c4e71babe) allow us to add html in navbar name, but navbar name is still limited to 50 char which is pretty short 