### PR TITLE
Add issues template with contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugs.yml
+++ b/.github/ISSUE_TEMPLATE/bugs.yml
@@ -25,14 +25,14 @@ body:
   attributes:
     label: "Errors / Logs"
     description: "If you have an error 500, please add error logs (located in `storage/logs`)"
-    placeholder: |
-      - "```"
-      - "<!-- Paste your logs here -->
-      - "```"
+    placeholder:
+    - "```"
+    - "<!-- Paste your logs here -->
+    - "```"
 - type: dropdown
   id: webserver
   attributes:
-    label: "Web serber"
+    label: "Web server"
     multiple: true
     options:
     - Apache
@@ -44,6 +44,7 @@ body:
     label: "Database type"
     options:
     - MySQL
+    - MariaDB
     - PostgreSQL
     - SQLite
     - SQLServer

--- a/.github/ISSUE_TEMPLATE/bugs.yml
+++ b/.github/ISSUE_TEMPLATE/bugs.yml
@@ -25,10 +25,7 @@ body:
   attributes:
     label: "Errors / Logs"
     description: "If you have an error 500, please add error logs (located in `storage/logs`)"
-    placeholder:
-    - "```"
-    - "<!-- Paste your logs here -->"
-    - "```"
+    placeholder: "<!-- Paste your logs here -->"
 - type: dropdown
   id: webserver
   attributes:

--- a/.github/ISSUE_TEMPLATE/bugs.yml
+++ b/.github/ISSUE_TEMPLATE/bugs.yml
@@ -4,7 +4,7 @@ assignees: []
 body:
 - type: markdown
   attributes:
-    value: "Something is not working as expected with Azuriom and the documentation doesn't answer: https://azuriom.com/en/docs."
+    value: "Something is not working as expected with Azuriom and the answer isn't in the [documentation](https://azuriom.com/docs)."
 - type: textarea
   id: description
   attributes:
@@ -49,3 +49,8 @@ body:
   id: php-version
   attributes:
     label: "PHP version"
+- type: textarea
+  id: context
+  attributes:
+    label: "Additional context"
+    description: "Add any other context about the problem here."

--- a/.github/ISSUE_TEMPLATE/bugs.yml
+++ b/.github/ISSUE_TEMPLATE/bugs.yml
@@ -1,0 +1,32 @@
+name: "Bug report"
+description: "Report something that gone wrong from Azuriom CMS"
+title: "Bug: "
+labels: ["bug"]
+assignees: []
+body:
+- type: markdown
+  attributes:
+    value: "Something is not working as expected with Azuriom and the documentation doesn't answer: https://azuriom.com/en/docs."
+- type: dropdown
+  id: platform
+  attributes:
+    label: "Which platform are you using ?"
+    multiple: true
+    options:
+    - Apache
+    - Nginx
+    - "I don't know"
+- type: textarea
+  id: reproduce-step
+  attributes:
+    label: "Step to reproduce"
+    description: "Explain all step to reproduce, with some element that can be particular to your setup and help us to fix it"
+    placeholder: "To reproduce, I do ... then ..."
+  validations:
+    required: true
+- type: textarea
+  id: error-logs
+  attributes:
+    label: "Errors / Logs"
+    description: "If applicable, add logs of error (copy/paste on pastebin/hastebin)"
+    placeholder: "Here is my link to error:"

--- a/.github/ISSUE_TEMPLATE/bugs.yml
+++ b/.github/ISSUE_TEMPLATE/bugs.yml
@@ -1,26 +1,22 @@
 name: "Bug report"
-description: "Report something that gone wrong from Azuriom CMS"
-title: "Bug: "
-labels: ["bug"]
+description: "Report something that isn't working as expected with Azuriom"
 assignees: []
 body:
 - type: markdown
   attributes:
     value: "Something is not working as expected with Azuriom and the documentation doesn't answer: https://azuriom.com/en/docs."
-- type: dropdown
-  id: platform
+- type: textarea
+  id: description
   attributes:
-    label: "Which platform are you using ?"
-    multiple: true
-    options:
-    - Apache
-    - Nginx
-    - "I don't know"
+    label: "Bug description"
+    description: "A clear and concise description of what the bug is."
+  validations:
+    required: true
 - type: textarea
   id: reproduce-step
   attributes:
     label: "Step to reproduce"
-    description: "Explain all step to reproduce, with some element that can be particular to your setup and help us to fix it"
+    description: "Explain all step to reproduce, with some element that can be particular to your setup and help us to fix it."
     placeholder: "To reproduce, I do ... then ..."
   validations:
     required: true
@@ -28,5 +24,30 @@ body:
   id: error-logs
   attributes:
     label: "Errors / Logs"
-    description: "If applicable, add logs of error (copy/paste on pastebin/hastebin)"
-    placeholder: "Here is my link to error:"
+    description: "If you have an error 500, please add error logs (located in `storage/logs`)"
+    placeholder: |
+      - "```"
+      - "<!-- Paste your logs here -->
+      - "```"
+- type: dropdown
+  id: webserver
+  attributes:
+    label: "Web serber"
+    multiple: true
+    options:
+    - Apache
+    - Nginx
+    - Other
+- type: dropdown
+  id: database
+  attributes:
+    label: "Database type"
+    options:
+    - MySQL
+    - PostgreSQL
+    - SQLite
+    - SQLServer
+- type: input
+  id: php-version
+  attributes:
+    label: "PHP version"

--- a/.github/ISSUE_TEMPLATE/bugs.yml
+++ b/.github/ISSUE_TEMPLATE/bugs.yml
@@ -27,7 +27,7 @@ body:
     description: "If you have an error 500, please add error logs (located in `storage/logs`)"
     placeholder:
     - "```"
-    - "<!-- Paste your logs here -->
+    - "<!-- Paste your logs here -->"
     - "```"
 - type: dropdown
   id: webserver

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://azuriom.com/en/docs
+    about: Check documentation and FAQ for questions already answered
+  - name: Discord for quick support
+    url: https://azuriom.com/discord
+    about: If you have a quick question, come on discord

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: Documentation
-    url: https://azuriom.com/en/docs
-    about: Check documentation and FAQ for questions already answered
+    url: https://azuriom.com/docs
+    about: Check out our documentation and FAQ for common questions.
   - name: Discord for quick support
     url: https://azuriom.com/discord
-    about: If you have a quick question, come on discord
+    about: You can join our Discord server to get support about installing and using Azuriom.

--- a/.github/ISSUE_TEMPLATE/suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/suggestion.yml
@@ -1,38 +1,19 @@
 name: "Suggestion"
 description: "Suggest an idea for Azuriom"
-title: "Suggestion: "
-labels: ["enhancement"]
 body:
 - type: markdown
   attributes:
-    value: "Use this template only if you want a new feature for Azuriom."
-- type: dropdown
-  id: concerned
-  attributes:
-    label: "What is concerned ?"
-    multiple: true
-    options:
-    - Users
-    - Plugins
-    - Themes
-    - Security
-    - Others
-- type: checkboxes
-  id: versions
-  attributes:
-    label: "Are you using v1.x ?"
-    options:
-      - label: "Yes"
+    value: "Suggest an idea for Azuriom. Before posting a suggestion, please check to see if your suggestion was already proposed in the [issues](https://github.com/Azuriom/Azuriom/issues). Suggestions for plugins/themes should be posted on the corresponding GitHub repository."
 - type: textarea
-  id: describe
+  id: description
   attributes:
-    label: "What is your idea ? What do you want ?"
-    description: "Explain your idea with screenshoots, example etc"
-    placeholder: "Explain your idea !"
+    label: "Description of your suggestion"
+    description: "Explain your idea with screenshoots, example, etc"
+    placeholder: "Explain your idea"
   validations:
     required: true
 - type: textarea
-  id: why
+  id: advantages
   attributes:
-    label: "Why this idea ? Why it should be accepted ?"
-    description: "What is the advantage of your suggestion ?"
+    label: "Advantages"
+    description: "What are the advantages of your suggestion or the alternatives you've considered?"

--- a/.github/ISSUE_TEMPLATE/suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/suggestion.yml
@@ -1,0 +1,38 @@
+name: "Suggestion"
+description: "Suggest an idea for Azuriom"
+title: "Suggestion: "
+labels: ["enhancement"]
+body:
+- type: markdown
+  attributes:
+    value: "Use this template only if you want a new feature for Azuriom."
+- type: dropdown
+  id: concerned
+  attributes:
+    label: "What is concerned ?"
+    multiple: true
+    options:
+    - Users
+    - Plugins
+    - Themes
+    - Security
+    - Others
+- type: checkboxes
+  id: versions
+  attributes:
+    label: "Are you using v1.x ?"
+    options:
+      - label: "Yes"
+- type: textarea
+  id: describe
+  attributes:
+    label: "What is your idea ? What do you want ?"
+    description: "Explain your idea with screenshoots, example etc"
+    placeholder: "Explain your idea !"
+  validations:
+    required: true
+- type: textarea
+  id: why
+  attributes:
+    label: "Why this idea ? Why it should be accepted ?"
+    description: "What is the advantage of your suggestion ?"


### PR DESCRIPTION
This make easier to create issue, and let everyone follow same template.

There is also some link to discord/docs to redirect people with already-answered questions.

You can test them on my [own fork](https://github.com/Elikill58/Azuriom)