### PR TITLE
Enable and download plugins via CLI

### DIFF
--- a/app/Console/Commands/PluginDisableCommand.php
+++ b/app/Console/Commands/PluginDisableCommand.php
@@ -5,21 +5,21 @@ namespace Azuriom\Console\Commands;
 use Azuriom\Extensions\Plugin\PluginManager;
 use Illuminate\Console\Command;
 
-class PluginEnableCommand extends Command
+class PluginDisableCommand extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'plugin:enable {id : The id of the plugin}';
+    protected $signature = 'plugin:disable {id : The id of the plugin}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Enable an installed plugin';
+    protected $description = 'Disable an enabled plugin';
 
     /**
      * Execute the console command.
@@ -28,13 +28,13 @@ class PluginEnableCommand extends Command
     {
         $id = $this->argument('id');
 
-        if (! $plugins->enable($id)) {
-            $this->error('Unable to enable plugin with id '.$id);
+        if (! $plugins->disable($id)) {
+            $this->error('Unable to disable plugin with id '.$id);
 
             return 1;
         }
 
-        $this->info('Plugin "'.$id.'" enabled.');
+        $this->info('Plugin "'.$id.'" disabled.');
 
         return 0;
     }

--- a/app/Console/Commands/PluginDownloadCommand.php
+++ b/app/Console/Commands/PluginDownloadCommand.php
@@ -32,14 +32,14 @@ class PluginDownloadCommand extends Command
         $extensionId = $this->argument('id');
 
         $plugin = $plugins->getOnlinePlugins()
-            ->first(fn ($plugin) =>  $plugin["extension_id"] == $extensionId);
+            ->first(fn ($plugin) =>  $plugin['extension_id'] == $extensionId);
 
         if ($plugin === null) {
             throw new RuntimeException("There is no plugin with extension_id '$extensionId',' ".
-            "or it is already downloaded or does not support this installation.");
+            'or it is already downloaded or does not support this installation.');
         }
 
-        $id = $plugin["id"];
+        $id = $plugin['id'];
         $plugins->install($id, $this->argument('version'));
         $this->info("Plugin $extensionId downloaded.");
 

--- a/app/Console/Commands/PluginDownloadCommand.php
+++ b/app/Console/Commands/PluginDownloadCommand.php
@@ -15,7 +15,7 @@ class PluginDownloadCommand extends Command
      */
     protected $signature = 'plugin:download
                             {id : Plugin\'s id we wish to download.}
-                            {version : Plugin\'s version.}';
+                            {version=latest : Plugin\'s version.}';
 
     /**
      * The console command description.

--- a/app/Console/Commands/PluginDownloadCommand.php
+++ b/app/Console/Commands/PluginDownloadCommand.php
@@ -4,7 +4,6 @@ namespace Azuriom\Console\Commands;
 
 use Azuriom\Extensions\Plugin\PluginManager;
 use Illuminate\Console\Command;
-use RuntimeException;
 
 class PluginDownloadCommand extends Command
 {
@@ -14,15 +13,15 @@ class PluginDownloadCommand extends Command
      * @var string
      */
     protected $signature = 'plugin:download
-                            {id : Plugin\'s id we wish to download.}
-                            {version=latest : Plugin\'s version.}';
+                            {id : The id of the plugin}
+                            {version? : The version of the plugin}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Download a plugin';
+    protected $description = 'Download a plugin from market.azuriom.com';
 
     /**
      * Execute the console command.
@@ -32,16 +31,17 @@ class PluginDownloadCommand extends Command
         $extensionId = $this->argument('id');
 
         $plugin = $plugins->getOnlinePlugins()
-            ->first(fn ($plugin) =>  $plugin['extension_id'] == $extensionId);
+            ->first(fn ($plugin) => $plugin['extension_id'] === $extensionId);
 
         if ($plugin === null) {
-            throw new RuntimeException("There is no plugin with extension_id '$extensionId',' ".
-            'or it is already downloaded or does not support this installation.');
+            $this->error('There is no plugin with id "'.$extensionId
+                .'", it is already downloaded or does not support this installation.');
+
+            return 1;
         }
 
-        $id = $plugin['id'];
-        $plugins->install($id, $this->argument('version'));
-        $this->info("Plugin $extensionId downloaded.");
+        $plugins->install($plugin['id'], $this->argument('version'));
+        $this->info('Plugin '.$extensionId.' downloaded.');
 
         return 0;
     }

--- a/app/Console/Commands/PluginDownloadCommand.php
+++ b/app/Console/Commands/PluginDownloadCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Azuriom\Console\Commands;
+
+use Azuriom\Extensions\Plugin\PluginManager;
+use Illuminate\Console\Command;
+use RuntimeException;
+
+class PluginDownloadCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'plugin:download
+                            {id : Plugin\'s id we wish to download.}
+                            {version : Plugin\'s version.}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Download a plugin';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(PluginManager $plugins)
+    {
+        $extensionId = $this->argument('id');
+
+        $plugin = $plugins->getOnlinePlugins()
+            ->first(fn ($plugin) =>  $plugin["extension_id"] == $extensionId);
+
+        if ($plugin === null) {
+            throw new RuntimeException("There is no plugin with extension_id '$extensionId',' ".
+            "or it is already downloaded or does not support this installation.");
+        }
+
+        $id = $plugin["id"];
+        $plugins->install($id, $this->argument('version'));
+        $this->info("Plugin $extensionId downloaded.");
+
+        return 0;
+    }
+}

--- a/app/Console/Commands/PluginEnableCommand.php
+++ b/app/Console/Commands/PluginEnableCommand.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Azuriom\Console\Commands;
+
+use Azuriom\Extensions\Plugin\PluginManager;
+use Illuminate\Console\Command;
+
+class PluginEnableCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'plugin:enable {id : Plugin\'s id we wish to enable.}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Enable a plugin';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(PluginManager $plugins)
+    {
+        $id = $this->argument('id');
+        $plugins->enable($id);
+        $this->info("Plugin $id enabled.");
+
+        return 0;
+    }
+}

--- a/app/Extensions/Plugin/PluginManager.php
+++ b/app/Extensions/Plugin/PluginManager.php
@@ -428,7 +428,7 @@ class PluginManager extends ExtensionManager
         });
     }
 
-    public function install($pluginId)
+    public function install($pluginId, string $pluginVersion = 'latest')
     {
         $updateManager = app(UpdateManager::class);
 
@@ -448,7 +448,7 @@ class PluginManager extends ExtensionManager
             $this->files->makeDirectory($pluginDir);
         }
 
-        $updateManager->download($pluginInfo, 'plugins/');
+        $updateManager->download($pluginInfo, 'plugins/', $pluginVersion);
         $updateManager->extract($pluginInfo, $pluginDir, 'plugins/');
 
         $this->createAssetsLink($plugin);

--- a/app/Extensions/UpdateManager.php
+++ b/app/Extensions/UpdateManager.php
@@ -129,7 +129,7 @@ class UpdateManager
         return $updates;
     }
 
-    public function download(array $info, string $tempDir = '')
+    public function download(array $info, string $tempDir = '', string $pluginVersion = 'latest')
     {
         $updatesPath = storage_path('app/updates/');
 
@@ -152,12 +152,19 @@ class UpdateManager
             $this->files->delete($path);
         }
 
+        $downloadUrl = $info['url'];
+        if ($pluginVersion !== 'latest') {
+            $downloadUrl = preg_replace("#\/updates\/\d+\/download$#", "/download/$pluginVersion", $downloadUrl);
+        }
+
         $this->prepareHttpRequest()
             ->withOptions(['sink' => $path])
-            ->get($info['url'])
+            ->get($downloadUrl)
             ->throw();
 
-        if (! hash_equals($info['hash'], hash_file('sha256', $path))) {
+        // TODO : Verify checksum for non-latest plugin's version
+        // Not possible for now because auzriom.com API does not return plugin's hash for older versions.
+        if (! hash_equals($info['hash'], hash_file('sha256', $path)) && $pluginVersion === 'latest') {
             $this->files->delete($path);
 
             throw new RuntimeException('The file hash do not match expected hash!');

--- a/app/Extensions/UpdateManager.php
+++ b/app/Extensions/UpdateManager.php
@@ -129,7 +129,7 @@ class UpdateManager
         return $updates;
     }
 
-    public function download(array $info, string $tempDir = '', string $pluginVersion = 'latest')
+    public function download(array $info, string $tempDir = '', bool $verifyHash = true)
     {
         $updatesPath = storage_path('app/updates/');
 
@@ -152,19 +152,12 @@ class UpdateManager
             $this->files->delete($path);
         }
 
-        $downloadUrl = $info['url'];
-        if ($pluginVersion !== 'latest') {
-            $downloadUrl = preg_replace("#\/updates\/\d+\/download$#", "/download/$pluginVersion", $downloadUrl);
-        }
-
         $this->prepareHttpRequest()
             ->withOptions(['sink' => $path])
-            ->get($downloadUrl)
+            ->get($info['url'])
             ->throw();
 
-        // TODO : Verify checksum for non-latest plugin's version
-        // Not possible for now because auzriom.com API does not return plugin's hash for older versions.
-        if ($pluginVersion === 'latest' && ! hash_equals($info['hash'], hash_file('sha256', $path))) {
+        if ($verifyHash && ! hash_equals($info['hash'], hash_file('sha256', $path))) {
             $this->files->delete($path);
 
             throw new RuntimeException('The file hash do not match expected hash!');

--- a/app/Extensions/UpdateManager.php
+++ b/app/Extensions/UpdateManager.php
@@ -164,7 +164,7 @@ class UpdateManager
 
         // TODO : Verify checksum for non-latest plugin's version
         // Not possible for now because auzriom.com API does not return plugin's hash for older versions.
-        if (! hash_equals($info['hash'], hash_file('sha256', $path)) && $pluginVersion === 'latest') {
+        if ($pluginVersion === 'latest' && ! hash_equals($info['hash'], hash_file('sha256', $path))) {
             $this->files->delete($path);
 
             throw new RuntimeException('The file hash do not match expected hash!');


### PR DESCRIPTION
This PR adds tow artisan commands :
* `php artisan plugin:download <id> <version>`
* `php artisan plugin:enable <id>`

Note that Azuriom won't be able to compare plugins checksums downloaded via the `plugin:download` command because azuriom.com API does not provide a way to get the checksum older plugin version. 