### PR TITLE
Add more Color rule assertions

### DIFF
--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -14,7 +14,7 @@ class RulesTest extends TestCase
     public function testColorRule()
     {
         $validColors = ['#ffffff', '#000000', '#ff0000'];
-        $invalidColors = ['#fff', 'fff', 'ff0000', '#f000', '#hh0000'];
+        $invalidColors = ['#fff', 'fff', 'ff0000', '#f000', '#hh0000', 'not-a-color', '#FF0000', '#FF00000'];
 
         foreach ($validColors as $color) {
             $this->assertTrue($this->validateRule($color, new Color()));


### PR DESCRIPTION
Part of https://github.com/Azuriom/Azuriom/issues/38

I noticed the regex for color rules is quite strict but we don't cover test cases for

1. strings that look nothing like color strings
2. strings that are valid hex but use uppercase characters
3. strings that are too long

So I've added them