### PR TITLE
Update webpack/loader-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5435,9 +5435,9 @@
             }
         },
         "node_modules/img-loader/node_modules/loader-utils": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-            "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.1.tgz",
+            "integrity": "sha512-1Qo97Y2oKaU+Ro2xnDMR26g1BwMT29jNbem1EvcujW2jqt+j5COXyscjM7bLQkM9HaxI7pkWeW7gnI072yMI9Q==",
             "dev": true,
             "dependencies": {
                 "big.js": "^5.2.2",
@@ -7901,9 +7901,9 @@
             }
         },
         "node_modules/sass-loader/node_modules/loader-utils": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-            "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.1.tgz",
+            "integrity": "sha512-1Qo97Y2oKaU+Ro2xnDMR26g1BwMT29jNbem1EvcujW2jqt+j5COXyscjM7bLQkM9HaxI7pkWeW7gnI072yMI9Q==",
             "dev": true,
             "dependencies": {
                 "big.js": "^5.2.2",
@@ -8905,9 +8905,9 @@
             }
         },
         "node_modules/vue-style-loader/node_modules/loader-utils": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-            "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.1.tgz",
+            "integrity": "sha512-1Qo97Y2oKaU+Ro2xnDMR26g1BwMT29jNbem1EvcujW2jqt+j5COXyscjM7bLQkM9HaxI7pkWeW7gnI072yMI9Q==",
             "dev": true,
             "dependencies": {
                 "big.js": "^5.2.2",
@@ -13659,9 +13659,9 @@
                     }
                 },
                 "loader-utils": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.1.tgz",
+                    "integrity": "sha512-1Qo97Y2oKaU+Ro2xnDMR26g1BwMT29jNbem1EvcujW2jqt+j5COXyscjM7bLQkM9HaxI7pkWeW7gnI072yMI9Q==",
                     "dev": true,
                     "requires": {
                         "big.js": "^5.2.2",
@@ -15430,9 +15430,9 @@
                     }
                 },
                 "loader-utils": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.1.tgz",
+                    "integrity": "sha512-1Qo97Y2oKaU+Ro2xnDMR26g1BwMT29jNbem1EvcujW2jqt+j5COXyscjM7bLQkM9HaxI7pkWeW7gnI072yMI9Q==",
                     "dev": true,
                     "requires": {
                         "big.js": "^5.2.2",
@@ -16231,9 +16231,9 @@
                     }
                 },
                 "loader-utils": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.1.tgz",
+                    "integrity": "sha512-1Qo97Y2oKaU+Ro2xnDMR26g1BwMT29jNbem1EvcujW2jqt+j5COXyscjM7bLQkM9HaxI7pkWeW7gnI072yMI9Q==",
                     "dev": true,
                     "requires": {
                         "big.js": "^5.2.2",


### PR DESCRIPTION
Prototype pollution vulnerability in function parseQuery in parseQuery.js in webpack loader-utils prior to version 2.0.3 via the name variable in parseQuery.js.
More info was sent to [security@azuriom.com](mailto:security@azuriom.com).