### PR TITLE
Fix verifyLink for ARK game

### DIFF
--- a/app/Games/Steam/Servers/Rcon.php
+++ b/app/Games/Steam/Servers/Rcon.php
@@ -13,6 +13,7 @@ class Rcon extends Query
         // This will call SourceQuery::SetRconPassword which will call SourceRcon::Authorize
         // Both methods will throw if the socket is not connected or password is wrong
         $this->connect(true);
+
         return true;
     }
 

--- a/app/Games/Steam/Servers/Rcon.php
+++ b/app/Games/Steam/Servers/Rcon.php
@@ -10,7 +10,13 @@ class Rcon extends Query
 
     public function verifyLink()
     {
-        return $this->connect(true)->GetInfo() !== null;
+        $query = $this->connect(true);
+
+        $reflection = new \ReflectionClass($query);
+        $property = $reflection->getProperty('Connected');
+        $property->setAccessible(true);
+
+        return $property->getValue($query);
     }
 
     public function sendCommands(array $commands, User $user, bool $needConnected = false)

--- a/app/Games/Steam/Servers/Rcon.php
+++ b/app/Games/Steam/Servers/Rcon.php
@@ -10,13 +10,10 @@ class Rcon extends Query
 
     public function verifyLink()
     {
-        $query = $this->connect(true);
-
-        $reflection = new \ReflectionClass($query);
-        $property = $reflection->getProperty('Connected');
-        $property->setAccessible(true);
-
-        return $property->getValue($query);
+        // This will call SourceQuery::SetRconPassword which will call SourceRcon::Authorize
+        // Both methods will throw if the socket is not connected or password is wrong
+        $this->connect(true);
+        return true;
     }
 
     public function sendCommands(array $commands, User $user, bool $needConnected = false)


### PR DESCRIPTION
It seems that ARK does not allow getinfo on rcon port So we verify the Connected property of SourceQuery using reflextion. 

when Connected is true, it means the rcon password is correct and the socket is open