### PR TITLE
fix(Profil): check email setting verification not to display alert

### DIFF
--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -73,7 +73,7 @@
         </div>
     </div>
 
-    @if($user->email !== null && ! $user->hasVerifiedEmail())
+    @if($user->email !== null && ! $user->hasVerifiedEmail() && setting('mail.users_email_verification', true))
         @if (session('resent'))
             <div class="alert alert-success mb-4" role="alert">
                 {{ trans('auth.verification.sent') }}


### PR DESCRIPTION
Here's a fix for email verification: by default, email is always activated even when you haven't configured your email server.

![image](https://github.com/Azuriom/Azuriom/assets/42696701/0fe6637c-01a5-4cc3-a975-bf1adc0ac756)
