### PR TITLE
Use only one parametter in FallbackController

### DIFF
--- a/app/Http/Controllers/FallbackController.php
+++ b/app/Http/Controllers/FallbackController.php
@@ -14,8 +14,10 @@ class FallbackController extends Controller
      *
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function get(Request $request, string $path)
+    public function get(Request $request)
     {
+        $path = $request->path();
+
         /** @var \Azuriom\Models\Redirect|null $redirect */
         $redirect = Redirect::enabled()->firstWhere('source', $path);
 


### PR DESCRIPTION
Sometimes, the fallback route is not called with a path and only injects the Request object : 

Too few arguments to function Azuriom\Http\Controllers\FallbackController::get(), 1 passed in /var/www/vhosts/anubispro.games/httpdocs/store/vendor/laravel/framework/src/Illuminate/Routing/Controller.php on line 54 and exactly 2 expected