### PR TITLE
feat: show filled icon on liked post

### DIFF
--- a/public/assets/js/script.js
+++ b/public/assets/js/script.js
@@ -56,8 +56,17 @@ document.querySelectorAll('[data-like-url]').forEach(function (el) {
         }).then(function (json) {
             el.classList.remove('active');
 
-            if (json.data.liked === true) {
+            const isLiked = json.data.liked;
+            const notLikedIcon = el.querySelector('.bi.bi-heart');
+            const likedIcon = el.querySelector('.bi.bi-heart-fill');
+
+            if (isLiked) {
                 el.classList.add('active');
+                notLikedIcon.classList.remove('bi-heart');
+                notLikedIcon.classList.add('bi-heart-fill');
+            } else {
+                likedIcon.classList.remove('bi-heart-fill');
+                likedIcon.classList.add('bi-heart');
             }
 
             const likesCount = el.querySelector('.likes-count');

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -33,7 +33,7 @@
 
             <div class="d-md-flex justify-content-between align-items-center">
                 <button type="button" class="btn btn-primary @if($post->isLiked()) active @endif mb-3" @guest disabled @endguest data-like-url="{{ route('posts.like', $post) }}">
-                    <i class="bi bi-heart"></i>
+                    <i class="bi @if($post->isLiked()) bi-heart-fill @else bi-heart @endif"></i>
                     @lang('messages.likes', ['count' => '<span class="likes-count">'.$post->likes->count().'</span>'])
                     <span class="d-none spinner-border spinner-border-sm load-spinner" role="status"></span>
                 </button>


### PR DESCRIPTION
Switches between filled and unfilled icons when liking and unlinking a post.

Closes: feature/bugfix-like-icon-indication