### PR TITLE
Fix English translation (admin -> Emails disabled)

### DIFF
--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -90,7 +90,7 @@ return [
         'cloudflare' => 'If you are using Cloudflare, you should install the Cloudflare Support plugin.',
         'recent_users' => 'Recent users',
         'active_users' => 'Active users',
-        'emails' => 'Emails are disabled. If a user forgets his password he will not be able to reset it. You can enable emails in the <a href=":url">mail settings</a>.',
+        'emails' => 'Emails are disabled. If a user forgets their password they will not be able to reset it. You can enable emails in the <a href=":url">mail settings</a>.',
     ],
 
     'settings' => [

--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -90,7 +90,7 @@ return [
         'cloudflare' => 'If you are using Cloudflare, you should install the Cloudflare Support plugin.',
         'recent_users' => 'Recent users',
         'active_users' => 'Active users',
-        'emails' => 'Emails are disabled. If a user forgets their password they will not be able to reset it. You can enable emails in the <a href=":url">mail settings</a>.',
+        'emails' => 'Emails are disabled. If a user forgets their password, they will not be able to reset it. You can enable emails in the <a href=":url">mail settings</a>.',
     ],
 
     'settings' => [


### PR DESCRIPTION
Updating a (probably mistranslated?) notification text to use more inclusive and gender-neutral language.
Changing "his" to "their" ensures that the language is move inclusive (see [Code of Conduct](https://github.com/Azuriom/Azuriom/blob/master/CODE_OF_CONDUCT.md)). This improves the user experience for all genders.