### PR TITLE
Add migrator support and improve config merge

### DIFF
--- a/app/Http/Controllers/Admin/ThemeController.php
+++ b/app/Http/Controllers/Admin/ThemeController.php
@@ -221,20 +221,25 @@ class ThemeController extends Controller
     protected static function appendConfig(array $config, array $replacement): array
     {
         foreach ($replacement as $key => $value) {
-            if (is_array($value)) {
-                // Replace instead of merge when `$replace` key is set to true
-                if ($value['$replace'] ?? false) {
-                    unset($value['$replace']);
-                    $config[$key] = $value;
-                    continue;
-                }
-
-                $config[$key] = static::appendConfig($config[$key] ?? [], $value);
-
+            if (! is_array($value)) {
+                $config[$key] = $value;
                 continue;
             }
 
-            $config[$key] = $value;
+            // Replace instead of merge when `$replace` key is set to true
+            if ($value['$replace'] ?? false) {
+                unset($value['$replace']);
+                $config[$key] = $value;
+                continue;
+            }
+
+            // Replace numeric arrays (lists) instead of merging
+            if (array_is_list($value)) {
+                $config[$key] = $value;
+                continue;
+            }
+
+            $config[$key] = static::appendConfig($config[$key] ?? [], $value);
         }
 
         return $config;

--- a/app/Http/Controllers/Admin/ThemeController.php
+++ b/app/Http/Controllers/Admin/ThemeController.php
@@ -85,10 +85,10 @@ class ThemeController extends Controller
                     $newConfig = $this->themes->readConfig($theme) ?? [];
 
                     $migratorPath = $this->themes->path('config/migrator.php', $theme);
-                    
+
                     if ($migratorPath !== null && $this->files->exists($migratorPath)) {
                         $migrator = $this->files->getRequire($migratorPath);
-                        
+
                         if (is_callable($migrator)) {
                             $mergedConfig = $migrator($oldConfig, $newConfig);
                         } else {
@@ -232,9 +232,9 @@ class ThemeController extends Controller
                     $config[$key] = [];
                     continue;
                 }
-                
+
                 $isIndexedArray = empty($value) || array_keys($value) === range(0, count($value) - 1);
-                
+
                 if ($isIndexedArray) {
                     $config[$key] = $value;
                 } else {


### PR DESCRIPTION
Support a theme-level config migrator and make config merging smarter. If a theme provides config/migrator.php and it is callable, it will be used to merge old and new config during update; otherwise fallback to previous array_merge behavior. Refactor appendConfig to return array and handle special cases: respect an `_empty` flag to clear values, replace indexed (numeric) arrays instead of merging, and recursively merge associative arrays. These changes ensure safer and more predictable config migrations when updating themes.