### PR TITLE
feat(#452): Add responsive images with srcset support

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -77,6 +77,13 @@ class Post extends Model
     ];
 
     /**
+     * The image sizes (in pixels) used for responsive images.
+     *
+     * @var int[]
+     */
+    protected array $imageSizes = [480, 768, 1200];
+
+    /**
      * Get the author of this post.
      */
     public function author()

--- a/app/Models/Traits/HasImage.php
+++ b/app/Models/Traits/HasImage.php
@@ -6,8 +6,8 @@ use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
-use Intervention\Image\ImageManager;
 use Intervention\Image\Drivers\GdDriver;
+use Intervention\Image\ImageManager;
 
 /**
  * Trait to link an image to a model.
@@ -180,11 +180,8 @@ trait HasImage
 
         foreach ($sizes as $size) {
             $image = ImageManager::withDriver(GdDriver::class)->read($file->getPathname());
-            
             $image->scaleDown(width: $size);
-            
             $variantPath = $this->resolveImagePath($this->getImageVariantName($filename, $size));
-            
             $this->getImageDisk()->put($variantPath, (string) $image->encode());
         }
     }

--- a/app/Models/Traits/HasImage.php
+++ b/app/Models/Traits/HasImage.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Intervention\Image\ImageManager;
+use Intervention\Image\Drivers\GdDriver;
 
 /**
  * Trait to link an image to a model.
@@ -177,18 +179,13 @@ trait HasImage
         }
 
         foreach ($sizes as $size) {
-            // Generate responsive image variants (requires server-side image processing)
-            // This is a placeholder for future implementation with Intervention/image or similar
-            // To implement, use Intervention/Image or similar:
-            // $image = Image::make($file->getPathname())->resize($size, null, function ($constraint) {
-            //     $constraint->aspectRatio();
-            // });
-            // $this->getImageDisk()->put(
-            //     $this->resolveImagePath($this->getImageVariantName($filename, $size)),
-            //     (string) $image->encode()
-            // );
-            // For now, this is reserved for future implementation
-            continue;
+            $image = ImageManager::withDriver(GdDriver::class)->read($file->getPathname());
+            
+            $image->scaleDown(width: $size);
+            
+            $variantPath = $this->resolveImagePath($this->getImageVariantName($filename, $size));
+            
+            $this->getImageDisk()->put($variantPath, (string) $image->encode());
         }
     }
 

--- a/app/Models/Traits/HasImage.php
+++ b/app/Models/Traits/HasImage.php
@@ -114,8 +114,92 @@ trait HasImage
         return $this->imageKey ?? 'image';
     }
 
+    /**
+     * Get the image srcset (if available).
+     */
+    public function imageSrcset(): ?string
+    {
+        $image = $this->getAttribute($this->getImageKey());
+
+        if ($image === null) {
+            return null;
+        }
+
+        $sizes = $this->getImageSizes();
+
+        if (empty($sizes)) {
+            return null;
+        }
+
+        $disk = $this->getImageDisk();
+        $srcset = [];
+
+        foreach ($sizes as $size) {
+            $variant = $this->resolveImagePath($this->getImageVariantName($image, $size));
+
+            if ($disk->exists($variant)) {
+                $srcset[] = url($disk->url($variant))." {$size}w";
+            }
+        }
+
+        return empty($srcset) ? null : implode(', ', $srcset);
+    }
+
     protected function resolveImagePath(string $path = ''): string
     {
         return ($this->imagePath ?? Str::snake(Str::pluralStudly(class_basename($this)))).'/'.$path;
     }
-}
+
+    protected function getImageSizes(): array
+    {
+        $sizes = property_exists($this, 'imageSizes') ? (array) $this->imageSizes : [];
+        $sizes = array_filter($sizes, fn ($size) => is_int($size) && $size > 0);
+        $sizes = array_values(array_unique($sizes));
+        sort($sizes);
+
+        return $sizes;
+    }
+
+    protected function getImageVariantName(string $filename, int $size): string
+    {
+        $name = pathinfo($filename, PATHINFO_FILENAME);
+        $extension = pathinfo($filename, PATHINFO_EXTENSION);
+
+        return $name.'-'.$size.'w.'.$extension;
+    }
+
+    protected function generateImageVariants(UploadedFile $file, string $filename): void
+    {
+        $sizes = $this->getImageSizes();
+
+        if (empty($sizes)) {
+            return;
+        }
+
+        foreach ($sizes as $size) {
+            // Generate responsive image variants (requires server-side image processing)
+            // This is a placeholder for future implementation with Intervention/image or similar
+            // $image = Image::make($file->getPathname())->resize($size, null, function ($constraint) {
+            //     $constraint->aspectRatio();
+            // });
+            // $this->getImageDisk()->put(
+            //     $this->resolveImagePath($this->getImageVariantName($filename, $size)),
+            //     (string) $image->encode()
+            // );
+        }
+    }
+
+    protected function deleteImageVariants(string $filename): void
+    {
+        $sizes = $this->getImageSizes();
+
+        if (empty($sizes)) {
+            return;
+        }
+
+        $disk = $this->getImageDisk();
+
+        foreach ($sizes as $size) {
+            $disk->delete($this->resolveImagePath($this->getImageVariantName($filename, $size)));
+        }
+    }

--- a/app/Models/Traits/HasImage.php
+++ b/app/Models/Traits/HasImage.php
@@ -179,6 +179,7 @@ trait HasImage
         foreach ($sizes as $size) {
             // Generate responsive image variants (requires server-side image processing)
             // This is a placeholder for future implementation with Intervention/image or similar
+            // To implement, use Intervention/Image or similar:
             // $image = Image::make($file->getPathname())->resize($size, null, function ($constraint) {
             //     $constraint->aspectRatio();
             // });
@@ -186,6 +187,8 @@ trait HasImage
             //     $this->resolveImagePath($this->getImageVariantName($filename, $size)),
             //     (string) $image->encode()
             // );
+            // For now, this is reserved for future implementation
+            continue;
         }
     }
 

--- a/app/Models/Traits/HasImage.php
+++ b/app/Models/Traits/HasImage.php
@@ -6,8 +6,6 @@ use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
-use Intervention\Image\Drivers\GdDriver;
-use Intervention\Image\ImageManager;
 
 /**
  * Trait to link an image to a model.
@@ -179,11 +177,53 @@ trait HasImage
         }
 
         foreach ($sizes as $size) {
-            $image = ImageManager::withDriver(GdDriver::class)->read($file->getPathname());
-            $image->scaleDown(width: $size);
-            $variantPath = $this->resolveImagePath($this->getImageVariantName($filename, $size));
-            $this->getImageDisk()->put($variantPath, (string) $image->encode());
+            $this->generateImageVariant($file->getPathname(), $filename, $size);
         }
+    }
+
+    /**
+     * Generate a single image variant at the specified size.
+     */
+    protected function generateImageVariant(string $filePath, string $filename, int $size): void
+    {
+        $image = imagecreatefromstring(file_get_contents($filePath));
+
+        if ($image === false) {
+            return;
+        }
+
+        $originalWidth = imagesx($image);
+        $originalHeight = imagesy($image);
+
+        // Calculate new dimensions maintaining aspect ratio
+        $ratio = $originalHeight / $originalWidth;
+        $newWidth = $size;
+        $newHeight = (int) ($size * $ratio);
+
+        // Create resized image
+        $resized = imagecreatetruecolor($newWidth, $newHeight);
+
+        if ($resized === false) {
+            imagedestroy($image);
+            return;
+        }
+
+        // Preserve transparency for PNG
+        imagealphablending($resized, false);
+        imagesavealpha($resized, true);
+
+        imagecopyresampled($resized, $image, 0, 0, 0, 0, $newWidth, $newHeight, $originalWidth, $originalHeight);
+
+        // Save variant
+        ob_start();
+        imagejpeg($resized, null, 85);
+        $imageContent = ob_get_clean();
+
+        $variantPath = $this->resolveImagePath($this->getImageVariantName($filename, $size));
+        $this->getImageDisk()->put($variantPath, $imageContent);
+
+        imagedestroy($image);
+        imagedestroy($resized);
     }
 
     protected function deleteImageVariants(string $filename): void

--- a/app/Models/Traits/HasImage.php
+++ b/app/Models/Traits/HasImage.php
@@ -202,8 +202,10 @@ trait HasImage
 
         // Create resized image
         $resized = imagecreatetruecolor($newWidth, $newHeight);
+
         if ($resized === false) {
             imagedestroy($image);
+
             return;
         }
 

--- a/app/Models/Traits/HasImage.php
+++ b/app/Models/Traits/HasImage.php
@@ -203,3 +203,4 @@ trait HasImage
             $disk->delete($this->resolveImagePath($this->getImageVariantName($filename, $size)));
         }
     }
+}

--- a/app/Models/Traits/HasImage.php
+++ b/app/Models/Traits/HasImage.php
@@ -202,7 +202,6 @@ trait HasImage
 
         // Create resized image
         $resized = imagecreatetruecolor($newWidth, $newHeight);
-
         if ($resized === false) {
             imagedestroy($image);
             return;

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "funkjedi/composer-include-files": "^1.1",
         "google/recaptcha": "^1.2",
         "guzzlehttp/guzzle": "^7.2",
+        "intervention/image": "^3.0",
         "laravel/framework": "^12.0",
         "laravel/socialite": "^5.4",
         "laravel/tinker": "^2.10.1",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
         "funkjedi/composer-include-files": "^1.1",
         "google/recaptcha": "^1.2",
         "guzzlehttp/guzzle": "^7.2",
-        "intervention/image": "^3.0",
         "laravel/framework": "^12.0",
         "laravel/socialite": "^5.4",
         "laravel/tinker": "^2.10.1",

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -26,7 +26,10 @@
             <div class="col-md-6">
                 <div class="post-preview card">
                     @if($post->hasImage())
-                        <img src="{{ $post->imageUrl() }}" class="card-img-top" alt="{{ $post->title }}">
+                        @php($srcset = $post->imageSrcset())
+                        <img src="{{ $post->imageUrl() }}"
+                             @if($srcset) srcset="{{ $srcset }}" sizes="(max-width: 768px) 100vw, 50vw" @endif
+                             class="card-img-top" alt="{{ $post->title }}">
                     @endif
                     <div class="card-body">
                         <h3 class="card-title">

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -20,7 +20,10 @@
     <h1>{{ $post->title }}</h1>
 
     @if($post->hasImage())
-        <img class="img-fluid rounded mb-3" src="{{ $post->imageUrl() }}" alt="{{ $post->title }}">
+        @php($srcset = $post->imageSrcset())
+        <img class="img-fluid rounded mb-3" src="{{ $post->imageUrl() }}"
+             @if($srcset) srcset="{{ $srcset }}" sizes="100vw" @endif
+             alt="{{ $post->title }}">
     @endif
 
     <div class="card mb-4">


### PR DESCRIPTION
- Add imageSrcset() method to HasImage trait to generate srcset attributes
- Add image size configuration (480px, 768px, 1200px) to Post model
- Add srcset and sizes attributes to post preview and full-size images
- Images are now served at appropriate resolutions based on device viewport