### PR TITLE
fix: log correct old value in action log entries

### DIFF
--- a/app/Models/Traits/Loggable.php
+++ b/app/Models/Traits/Loggable.php
@@ -52,8 +52,10 @@ trait Loggable
 
     public function createLogEntries(ActionLog $log): void
     {
+        $previous = $this->getPrevious();
+
         foreach ($this->getChanges() as $attribute => $value) {
-            $original = $this->getOriginal($attribute);
+            $original = $previous[$attribute] ?? null;
 
             if ($this->shouldLogAttribute($attribute) && $this->isValidLogType($original) && $this->isValidLogType($value)) {
                 $log->entries()->create([


### PR DESCRIPTION
## Problem

When a model is updated and its action log entries are created **after** `save()` (as in `Admin\UserController::update()`), every entry is logged with `old_value == new_value`.

For example, editing a user in the admin panel produces a log like:

| # | Old value | New value |
|---|-----------|-----------|
| money | 10 | 10 |

…even though the value actually changed.

## Cause

`Loggable::createLogEntries()` reads the previous value with `getOriginal($attribute)`:

```php
foreach ($this->getChanges() as $attribute => $value) {
    $original = $this->getOriginal($attribute);
    ...
}
```

But by the time it runs, the model has already been saved. Eloquent's `save()` calls `finishSave()` → `syncOriginal()`, which resyncs the original state to the current attributes. So `getOriginal()` returns the **new** value, and `old_value` ends up equal to `new_value`.

This affects any caller that logs after saving — `UserController::update()` being the visible one (it sets `$logEvents = []` on `User` and logs manually after `$user->save()`).

## Fix

Use `getPrevious()` instead. It is populated in `syncChanges()` (called during `performUpdate`, **before** `syncOriginal()`) and remains available after `save()`, so it holds the genuine pre-save values of the changed attributes.

This also keeps working for the automatic logging path in `bootLoggable()` (fired on the `updated` event, after `syncChanges()`), so no behavior is lost there.